### PR TITLE
Add GA and GM command card types

### DIFF
--- a/app/GAOParser.hs
+++ b/app/GAOParser.hs
@@ -66,6 +66,8 @@ card = do
       gsymCard,
       bndCard,
       gwCard,
+      gaCard,
+      gmCard,
       frCard,
       enCard,
       geCard,
@@ -86,7 +88,9 @@ cmCard,
   gsymCard,
   bndCard,
   gwCard,
+  gaCard,
   geCard,
+  gmCard,
   frCard,
   ldCard,
   gnCard,
@@ -126,6 +130,24 @@ gwCard = do
   [epx, epy, epz] <- count 3 $ lexeme expr
   r <- lexeme expr
   return $ Card $ GW ct segc (Point3 spx spy spz) (Point3 epx epy epz) (Radius r)
+gaCard = do
+  void $ lexeme $ symbol "GA"
+  ct <- lexeme L.decimal
+  segc <- lexeme L.decimal
+  arc_radius <- lexeme expr
+  [a1, a2] <- count 2 $ lexeme expr
+  wire_radius <- lexeme expr
+  seg_len <- lexeme expr
+  [unused1, unused2] <- count 2 $ lexeme expr
+  return $ Card $ GA ct segc (Radius arc_radius) (Angle a1) (Angle a2) (Radius wire_radius) (Length seg_len) (Unused unused1) (Unused unused2)
+gmCard = do
+  void $ lexeme $ symbol "GM"
+  tag_incr <- lexeme L.decimal
+  new_structs <- lexeme L.decimal
+  [rx, ry, rz] <- count 3 $ lexeme expr
+  [dx, dy, dz] <- count 3 $ lexeme expr
+  tag_start <- lexeme L.decimal
+  return $ Card $ GM tag_incr new_structs (Point3 rx ry rz) (Point3 dx dy dz) tag_start
 bndCard = gaodbg "bndCard" $ do
   void $ lexeme $ symbol "BND"
   i <- T.pack <$> lexeme (some alphaNumChar)

--- a/app/Phenotype.hs
+++ b/app/Phenotype.hs
@@ -59,6 +59,23 @@ evalCard env (Card (GW ct sc (Point3 spx spy spz) (Point3 epx epy epz) (Radius r
       epz' = eval env epz
       r' = eval env r
   return (env, Card (GW ct sc (Point3 spx' spy' spz') (Point3 epx' epy' epz') (Radius r')))
+evalCard env (Card (GA ct sc (Radius r1) (Angle a1) (Angle a2) (Radius r2) (Length l1) (Unused u1) (Unused u2))) = do
+  let r1' = eval env r1
+      a1' = eval env a1
+      a2' = eval env a2
+      r2' = eval env r2
+      l1' = eval env l1
+      u1' = eval env u1
+      u2' = eval env u2
+  return (env, Card (GA ct sc (Radius r1') (Angle a1') (Angle a2') (Radius r2') (Length l1') (Unused u1') (Unused u2')))
+evalCard env (Card (GM cto sc (Point3 ax ay az) (Point3 dx dy dz) cts)) = do
+  let ax' = eval env ax
+      ay' = eval env ay
+      az' = eval env az
+      dx' = eval env dx
+      dy' = eval env dy
+      dz' = eval env dz
+  return (env, Card (GM cto sc (Point3 ax' ay' az') (Point3 dx' dy' dz') cts))
 evalCard env (Card (CM t)) = pure (env, Card (CM t))
 evalCard env (Card (CE t)) = pure (env, Card (CE t))
 evalCard env (Card (EX t)) = pure (env, Card (EX t))
@@ -120,6 +137,40 @@ renderCard _ (Card (GW ct sc (Point3 spx spy spz) (Point3 epx epy epz) (Radius r
       <> toText epz
       <> tab
       <> toText r
+      <> nl
+renderCard _ (Card (GA ct sc (Radius r1) (Angle a1) (Angle a2) (Radius r2) (Length l1) (Unused u1) (Unused u2))) =
+  run $
+    padr (string "GA") <> tab <> padl (decimal ct) <> tab <> padl (decimal sc) <> tab
+      <> toText r1
+      <> tab
+      <> toText a1
+      <> tab
+      <> toText a2
+      <> tab
+      <> toText r2
+      <> tab
+      <> toText l1
+      <> tab
+      <> toText u1
+      <> tab
+      <> toText u2
+      <> nl
+renderCard _ (Card (GM cto sc (Point3 ax ay az) (Point3 dx dy dz) cts)) =
+  run $
+    padr (string "GM") <> tab <> padl (decimal cto) <> tab <> padl (decimal sc) <> tab
+      <> toText ax
+      <> tab
+      <> toText ay
+      <> tab
+      <> toText az
+      <> tab
+      <> toText dx
+      <> tab
+      <> toText dy
+      <> tab
+      <> toText dz
+      <> tab
+      <> padl (decimal cts)
       <> nl
 renderCard _ (Card (SYM _ _)) = ""
 renderCard _ (Card (GSYM _ _)) = ""

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -131,6 +131,8 @@ data CardType a
   = CM Text
   | CE Text
   | GW CardTag SegmentCount (Point3 a) (Point3 a) (Radius a)
+  | GA CardTag SegmentCount (Radius a) (Angle a) (Angle a) (Radius a) (Length a) (Unused a) (Unused a)
+  | GM CardTag SegmentCount (Point3 a) (Point3 a) CardTag
   | GE GroundType
   | FR Text
   | LD
@@ -159,7 +161,16 @@ type CardTag = Int
 
 type SegmentCount = Int
 
+newtype Unused a = Unused a
+  deriving (Show)
+
+newtype Length a = Length a
+  deriving (Show)
+
 newtype Radius a = Radius a
+  deriving (Show)
+
+newtype Angle a = Angle a
   deriving (Show)
 
 data Point3 a = Point3 {x, y, z :: a}


### PR DESCRIPTION
I'm working on a circular quad beam antenna, and so was using the GA and GM card types rather than only the GW card. This PR adds support for those types to the parser and phenotype; it seems to work well for my antenna! When I'm done with it I could add my file to the examples/ directory as well.