### PR TITLE
Support inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ a BND Card for 2m Band that has only a few steps, to make optimization fast and 
 
 Example : examples/awx/
 
+## Comments
+
+Lines beginning with hash (`#`) and exist anywhere in the file. This are inline comments. They are passed
+though unmodified and ignored by by xnec2c / nec2c.
+
+    # this is a comment
+    SYM freq := 145800
+
 # From .gao file to .gao.nec files
 
 After you prepared your .gao file for your antenna model, you can invoke the optimizer.

--- a/app/GAOParser.hs
+++ b/app/GAOParser.hs
@@ -79,7 +79,8 @@ card = do
       symCard,
       gsymCard,
       gaoCard,
-      otherCard
+      otherCard,
+      comment
     ]
 
 cmCard,
@@ -99,7 +100,8 @@ cmCard,
   ekCard,
   rpCard,
   gaoCard,
-  otherCard ::
+  otherCard,
+  comment ::
     Parser (Card Expr)
 cmCard = gaodbg "CM" $ do
   void $ lexeme $ symbol "CM"
@@ -174,6 +176,11 @@ otherCard = gaodbg "Other" $ do
   ct <- lexeme $ some alphaNumChar
   rest <- lexeme $ many printChar
   return $ Card $ Other (T.pack ct) (T.pack rest)
+comment = gaodbg "Comment" $ do
+  void $ lexeme $ single '#'
+  rest <- lexeme $ many printChar 
+  return $ Card $ Other "#" (T.pack rest)
+
 
 identifier :: Parser Text
 identifier = do

--- a/examples/dipole/dipole.gao
+++ b/examples/dipole/dipole.gao
@@ -1,7 +1,9 @@
 CM --- NEC2 Input File created or edited by xnec2c 4.4.12 ---
 CE --- End Comments ---
 GSYM gbase := [0,5...4,0]
+# khz
 SYM freq := 145800
+# speed of light
 SYM c := 300000
 SYM vk := 0,96
 SYM lambda := vk * c / freq
@@ -9,8 +11,10 @@ SYM lamq := scale * (lambda / 4)
 SYM base := gbase * lambda 
 GSYM r := [0,002...0,01]
 GSYM scale := [0,7...1,5]
+# --- GEOMETRY
 GW     1    15   0,00000E+00-lamq  0,00000E+00  base       0,00000E+00+lamq  0,00000E+00  base    r
 GE    -1     0   0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00
+# --- END GEOMETRY
 FR     0    30     0     0  1,43800E+02  0,08200E+00  1,46200E+02  0,00000E+00  0,00000E+00  0,00000E+00
 LD     5     0     0      0  2,48000E+07  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00
 GN     2     0     0      0  1,20000E+01  1,00000E-02  0,00000E+00  0,00000E+00  0,00000E+00  0,00000E+00


### PR DESCRIPTION
I have a little something that I find quite handy, which is comment support in gao files. nec2c / xnec2c supports inline comments with hash (`#`), so I would say gao should too.

See https://github.com/cvvs/nec2c.